### PR TITLE
Minimize Public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ end
 Then, in the corresponding view, use the asset helpers:
 
 ```erb
+<!-- app/views/ember/index.html.erb -->
+
 <%= include_ember_script_tags :frontend %>
 <%= include_ember_stylesheet_tags :frontend %>
 ```

--- a/lib/ember_cli/assets/directory_asset_map.rb
+++ b/lib/ember_cli/assets/directory_asset_map.rb
@@ -2,7 +2,7 @@ module EmberCli
   module Assets
     class DirectoryAssetMap
       def initialize(directory)
-        @directory = Pathname(directory)
+        @directory = Pathname.new(directory)
       end
 
       def to_h
@@ -11,6 +11,10 @@ module EmberCli
           "prepend" => "assets/",
         }
       end
+
+      private
+
+      attr_reader :directory
 
       def files_with_data
         files.reduce({}) do |manifest, file|
@@ -22,10 +26,9 @@ module EmberCli
         end
       end
 
-      private
 
       def files
-        @directory.children.map { |path| File.new(path) }
+        directory.children.map { |path| File.new(path) }
       end
     end
   end

--- a/lib/ember_cli/assets/ext/action_dispatch/routing/mapper.rb
+++ b/lib/ember_cli/assets/ext/action_dispatch/routing/mapper.rb
@@ -2,9 +2,10 @@ module ActionDispatch
   module Routing
     class Mapper
       def mount_ember_assets(app_name, to: "/")
-        dist_directory = EmberCli[app_name].paths.dist
+        app = EmberCli[app_name]
+        rack_app = Rack::File.new(app.dist_path.to_s)
 
-        mount Rack::File.new(dist_directory.to_s) => to
+        mount rack_app => to
       end
     end
   end

--- a/lib/ember_cli/assets/lookup.rb
+++ b/lib/ember_cli/assets/lookup.rb
@@ -6,7 +6,6 @@ module EmberCli
   module Assets
     class Lookup
       def initialize(app)
-        @app = app
         @paths = Paths.new(app)
       end
 
@@ -20,7 +19,7 @@ module EmberCli
 
       private
 
-      attr_reader :app, :paths
+      attr_reader :paths
 
       def asset_map
         AssetMap.new(


### PR DESCRIPTION
- Depend on public API
- Remove unnecessary `attr_reader`
- Replace instance variables with private `attr_reader` invocations
- Clean up documentation
