### PR TITLE
documentation congruence for prepend param on include helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ path to prepend:
 <%= include_ember_script_tags :frontend, prepend: "/" %>
 <%= include_ember_stylesheet_tags :frontend, prepend: "/" %>
 
-<%= include_ember_script_tags :admin_panel, prepend: "/" %>
-<%= include_ember_stylesheet_tags :admin_panel, prepend: "/" %>
+<%= include_ember_script_tags :admin_panel, prepend: "/admin_panel/" %>
+<%= include_ember_stylesheet_tags :admin_panel, prepend: "/admin_panel/" %>
 ```
 
 ## EmberCLI support


### PR DESCRIPTION
The current README likely has a typo, but in any case the example for `admin_panel` can be confusing when taken in context of the sample project in the `base` tag example above. This corrects the example, assuming the previous context.
