### PR TITLE
Update engine.rb to work with zeitwerk

### DIFF
--- a/lib/ember_cli/assets/engine.rb
+++ b/lib/ember_cli/assets/engine.rb
@@ -2,7 +2,9 @@ module EmberCli
   module Assets
     class Engine < ::Rails::Engine
       initializer "ember-cli-rails-assets" do
-        ActionController::Base.helper EmberCliRailsAssetsHelper
+        ActiveSupport.on_load(:action_controller) do
+          ActionController::Base.helper EmberCliRailsAssetsHelper
+        end
       end
     end
   end


### PR DESCRIPTION
The new zeitwerk autoloader in Rails 6 (will be default in 6.1) throws errors when autoloading user-land constants during initialization, by moving this logic to an `on_load` function, we solve that problem.

There is an equivalent update to be made in ember-cli-rails's `engine.rb` as well.