### PR TITLE
Mixin `app/helpers` through Rails Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 master
 ------
 
+* Rely on Rails Engine to mix `app/helpers` modules into
+  `ActionController::Base`
+
 0.7.0
 -----
 

--- a/lib/ember_cli/assets/engine.rb
+++ b/lib/ember_cli/assets/engine.rb
@@ -1,9 +1,6 @@
 module EmberCli
   module Assets
     class Engine < ::Rails::Engine
-      config.to_prepare do
-        ActionController::Base.helper EmberCliRailsAssetsHelper
-      end
     end
   end
 end


### PR DESCRIPTION
Related to [thoughtbot/ember-cli-rails#580][#580].

In response to a Zeitwerk autoload warning message, this commit removes
a reference to `EmberCliRailsAssetsHelper` from the
`lib/ember_cli/assets/engine`, and instead relies on the default Engine
behavior.

[#580]: https://github.com/thoughtbot/ember-cli-rails/pull/580