### PR TITLE
Use `to_prepare` for autoloading to support Rails 7

### DIFF
--- a/lib/ember_cli/assets/engine.rb
+++ b/lib/ember_cli/assets/engine.rb
@@ -1,7 +1,7 @@
 module EmberCli
   module Assets
     class Engine < ::Rails::Engine
-      initializer "ember-cli-rails-assets" do
+      config.to_prepare do
         ActionController::Base.helper EmberCliRailsAssetsHelper
       end
     end


### PR DESCRIPTION
In Rails 7, previous code raises a NameError.
```
/bundle/ruby/3.0.0/gems/ember-cli-rails-assets-0.6.2/lib/ember_cli/assets/engine.rb:5:in `block in <class:Engine>': uninitialized constant EmberCli::Assets::Engine::EmberCliRailsAssetsHelper (NameError)
```

Using `to_prepare` is recommended to use autoload since Rails 7.
https://github.com/rails/rails/commit/dc047f71b824bfbf4a8e16e2445994d91359d9a2