### PR TITLE
Support ember-auto-import 2.x

### DIFF
--- a/ember-cli-rails-assets.gemspec
+++ b/ember-cli-rails-assets.gemspec
@@ -15,4 +15,6 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.files = Dir["{app,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+
+  s.add_dependency 'nokogiri'
 end

--- a/lib/ember_cli/assets/lookup.rb
+++ b/lib/ember_cli/assets/lookup.rb
@@ -34,11 +34,7 @@ module EmberCli
       end
 
       def asset_map_hash
-        if asset_map_file.present? && asset_map_file.exist?
-          JSON.parse(asset_map_file.read)
-        else
-          DirectoryAssetMap.new(paths.assets)
-        end
+        DirectoryAssetMap.new(paths.assets)
       end
 
       def name_from_package_json

--- a/lib/ember_cli/assets/lookup.rb
+++ b/lib/ember_cli/assets/lookup.rb
@@ -25,6 +25,7 @@ module EmberCli
         AssetMap.new(
           name: name_from_package_json,
           asset_map: asset_map_hash.to_h,
+          index_html: paths.index_html,
         )
       end
 

--- a/lib/ember_cli/assets/paths.rb
+++ b/lib/ember_cli/assets/paths.rb
@@ -17,6 +17,10 @@ module EmberCli
         app.root_path.join("package.json")
       end
 
+      def index_html
+        app.dist_path.join("index.html")
+      end
+
       protected
 
       attr_reader :app


### PR DESCRIPTION
ember-auto-import 2.x, that [depends on webpack 5](https://github.com/ef4/ember-auto-import/blob/main/docs/upgrade-guide-2.0.md) serves chunked assets like the following:

- Before
``` html
<script src="/my-app/assets/vendor.js"></script>
<script src="/my-app/assets/my-app.js"></script>
```

- After
``` html
<script src="/my-app/assets/vendor.js"></script>
<script src="/my-app/assets/chunk.vendors-node_modules_rails_ujs_lib_assets_compiled_rails-ujs_js.fed412620e714e8dca24.js"></script>
<script src="/my-app/assets/chunk.app.9b607ebf64d847a96b97.js"></script>
<script src="/my-app/assets/my-app.js"></script>
```


To find them correctly, `dist/index.html` should be used.
