### PR TITLE
Replace npm with yarn to fix CI

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -18,6 +18,6 @@ fi
 root="$(pwd)"
 
 cd ${root}/spec/dummy/my-app &&
-  npm install --save-dev ember-cli-rails-addon@rondale-sc/ember-cli-rails-addon
+  yarn add --dev ember-cli-rails-addon@rondale-sc/ember-cli-rails-addon
 
 cd ${root}/spec/dummy && bundle exec rake ember:install

--- a/spec/dummy/config/initializers/ember.rb
+++ b/spec/dummy/config/initializers/ember.rb
@@ -1,3 +1,3 @@
 EmberCli.configure do |c|
-  c.app "my-app"
+  c.app "my-app", yarn: true
 end


### PR DESCRIPTION
NPM doesn't resolve dependencies of https://github.com/ember-cli/ember-new-output for now.

``` console
$ node -v
v16.19.0
$ npm -v
8.19.3
$ git clone https://github.com/ember-cli/ember-new-output
Cloning into 'ember-new-output'...
remote: Enumerating objects: 1379, done.
remote: Counting objects: 100% (244/244), done.
remote: Compressing objects: 100% (88/88), done.
remote: Total 1379 (delta 168), reused 214 (delta 143), pack-reused 1135
Receiving objects: 100% (1379/1379), 160.90 KiB | 10.06 MiB/s, done.
Resolving deltas: 100% (937/937), done.
$ cd ember-new-output
$ npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: my-app@0.0.0
npm ERR! Found: ember-source@4.11.0-beta.1
npm ERR! node_modules/ember-source
npm ERR!   dev ember-source@"~4.11.0-beta.1" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer ember-source@">=3.8.0" from @ember/test-helpers@2.9.3
npm ERR! node_modules/@ember/test-helpers
npm ERR!   dev @ember/test-helpers@"^2.9.3" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/ryunosuke.sato/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/ryunosuke.sato/.npm/_logs/2023-02-11T01_55_55_537Z-debug-0.log
```

On the other hand, Yarn can do it.

``` console
yarn -v
1.22.19
$ yarn install
yarn install v1.22.19
...
success Saved lockfile.
✨  Done in 75.81s.
```

Since this is not a bug of ember-cli-rails-assets, this commit switches package manager to pass CI.
