### PR TITLE
fix: Update asset_map to handle assets more than one level deep

### DIFF
--- a/lib/ember_cli/assets/directory_asset_map.rb
+++ b/lib/ember_cli/assets/directory_asset_map.rb
@@ -16,19 +16,20 @@ module EmberCli
 
       attr_reader :directory
 
+      # Returns a hash of files in the directory
       def files_with_data
-        files.reduce({}) do |manifest, file|
-          name = File.basename(file.path)
-
+        files.each_with_object({}) do |file, manifest|
+          name = Pathname.new(file).relative_path_from(directory).to_s
           manifest[name] = name
-
-          manifest
         end
       end
-
+      
+      # Returns a recursive list of files in the directory
 
       def files
-        directory.children.map { |path| File.new(path) }
+        directory.glob('**/*').select { |f| f.file? }.map do |file|
+          File.new(file)
+        end
       end
     end
   end

--- a/spec/lib/ember_cli/assets/asset_map_spec.rb
+++ b/spec/lib/ember_cli/assets/asset_map_spec.rb
@@ -65,7 +65,40 @@ describe EmberCli::Assets::AssetMap do
         "foo/vendor-abc123.css",
       ])
     end
+    
+    it 'can find additional CSS files found inside the HTML' do
+      asset_map = {
+        'assets' => {
+          'not-a-match' => {},
+          'bar.css' => 'bar-abc123.css',
+          'vendor.css' => 'vendor-abc123.css',
+          'additional.css' => 'additional-abc123.css',
+          'here/is/another/file.css' => 'here/is/another/file-abc123.css'
+        },
+        'prepend' => 'foo/'
+      }
+      index_html = StringIO.new(<<~HTML)
+        <html>
+          <head>
+            <link rel="stylesheet" href="bar-abc123.css"></link>
+            <link rel="stylesheet" href="vendor-abc123.css"></link>
+            <link rel="stylesheet" href="additional-abc123.css"></link>
+            <link rel="stylesheet" href="here/is/another/file-abc123.css"></link>
+          </head>
+        </html>
+      HTML
+      assets = build_assets(name: 'bar', asset_map: asset_map, index_html: index_html)
 
+      stylesheets = assets.stylesheets
+
+      expect(stylesheets).to match_array([
+        "foo/additional-abc123.css",
+        "foo/bar-abc123.css", 
+        "foo/here/is/another/file-abc123.css", 
+        "foo/vendor-abc123.css"
+      ])
+    end
+    
     context "when the asset_map is empty" do
       it "raises a BuildError" do
         assets = build_assets(asset_map: {}, name: "bar", index_html: StringIO.new)

--- a/spec/lib/ember_cli/assets/directory_asset_map_spec.rb
+++ b/spec/lib/ember_cli/assets/directory_asset_map_spec.rb
@@ -9,15 +9,17 @@ describe EmberCli::Assets::DirectoryAssetMap do
       create_file("first")
       create_file("second")
       create_file("third")
-
+      create_file("fourth/fifth")
       directory_manifest = build_directory_asset_map(directory).to_h
 
       expect(directory_manifest["prepend"]).to eq("assets/")
-      expect(directory_manifest["assets"]).to match a_hash_including(
+      # Strict match the hash
+      expect(directory_manifest["assets"]).to eq({
         "first" => "first",
         "second" => "second",
         "third" => "third",
-      )
+        "fourth/fifth" => "fourth/fifth",
+      })
     end
   end
 
@@ -28,6 +30,7 @@ describe EmberCli::Assets::DirectoryAssetMap do
   def create_file(name)
     path = directory.join(name)
 
+    FileUtils.mkdir_p(File.dirname(path))
     FileUtils.touch(path)
 
     File.new(path)


### PR DESCRIPTION
When a CSS files is used in the `index.html` that has  a path like such: `/assets/dir1/dir2/dir3/library.css`. The asset map throws an exception that it can't be found. This is because the DirectoryAssetMap only looks at children, and not the entire tree. This now returns all the files found recursively for it to check. In addition, it returns the relative path, so there isn't a risk of two files in different directories colliding.

Addresses issue: https://github.com/seanpdoyle/ember-cli-rails-assets/issues/24