### PR TITLE
Update Node.js version to 18 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: "16.x"
+          node-version: "18.x"
 
       - name: Setup Google Chrome
         uses: browser-actions/setup-chrome@latest


### PR DESCRIPTION
To fix the following error:
```
error my-app@0.0.0: The engine "node" is incompatible with this module. Expected version ">= 18". Got "16.20.2"
error Found incompatible module.
```