### PR TITLE
Update Node.js version to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: "18.x"
+          node-version: "20.x"
 
       - name: Setup Google Chrome
         uses: browser-actions/setup-chrome@latest


### PR DESCRIPTION
To fix the following error on CI.
```
error mktemp@2.0.2: The engine "node" is incompatible with this module. Expected version "20 || 22 || 24". Got "18.20.8"
error Found incompatible module.
```
https://github.com/tricknotes/ember-cli-rails-assets/actions/runs/24065729896/job/70191312530?pr=31#step:7:50